### PR TITLE
chore(deps): bump dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1838,9 +1838,9 @@
       }
     },
     "@sasjs/core": {
-      "version": "2.48.2",
-      "resolved": "https://registry.npmjs.org/@sasjs/core/-/core-2.48.2.tgz",
-      "integrity": "sha512-68PDj3srBJTSPQzEp/vEZ8B3HBZhcl0aPL2+nrkwTybKfQjp4BO/B71RrmVU2NcpiufI37MthcU01ZYAuiMDJQ=="
+      "version": "2.48.6",
+      "resolved": "https://registry.npmjs.org/@sasjs/core/-/core-2.48.6.tgz",
+      "integrity": "sha512-5kCf4TdCVOYve4wSHVTi+db34hknDwvY2C/JVEPHT6T3CkQ5cnwRVPSFz/1WzXzcVvdUi4ag5xd9SDOsU12oWA=="
     },
     "@sasjs/utils": {
       "version": "2.31.0",
@@ -12579,11 +12579,11 @@
       "integrity": "sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg=="
     },
     "react-router": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.2.0.tgz",
-      "integrity": "sha512-smz1DUuFHRKdcJC0jobGo8cVbhO3x50tCL4icacOlcwDOEQPq4TMqwx3sY1TP+DvtTgz4nm3thuo7A+BK2U0Dw==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.2.1.tgz",
+      "integrity": "sha512-lIboRiOtDLFdg1VTemMwud9vRVuOCZmUIT/7lUoZiSpPODiiH1UQlfXy+vPLC/7IWdFYnhRwAyNqA/+I7wnvKQ==",
       "requires": {
-        "@babel/runtime": "^7.1.2",
+        "@babel/runtime": "^7.12.13",
         "history": "^4.9.0",
         "hoist-non-react-statics": "^3.1.0",
         "loose-envify": "^1.3.1",
@@ -12603,15 +12603,15 @@
       }
     },
     "react-router-dom": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.2.0.tgz",
-      "integrity": "sha512-gxAmfylo2QUjcwxI63RhQ5G85Qqt4voZpUXSEqCwykV0baaOTQDR1f0PmY8AELqIyVc0NEZUj0Gov5lNGcXgsA==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.0.tgz",
+      "integrity": "sha512-ObVBLjUZsphUUMVycibxgMdh5jJ1e3o+KpAZBVeHcNQZ4W+uUGGWsokurzlF4YOldQYRQL4y6yFRWM4m3svmuQ==",
       "requires": {
-        "@babel/runtime": "^7.1.2",
+        "@babel/runtime": "^7.12.13",
         "history": "^4.9.0",
         "loose-envify": "^1.3.1",
         "prop-types": "^15.6.2",
-        "react-router": "5.2.0",
+        "react-router": "5.2.1",
         "tiny-invariant": "^1.0.2",
         "tiny-warning": "^1.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@material-ui/core": "^4.12.3",
     "@material-ui/icons": "^4.11.2",
     "@sasjs/adapter": "^2.11.4",
-    "@sasjs/core": "^2.48.2",
+    "@sasjs/core": "^2.48.6",
     "@sasjs/utils": "^2.31.0",
     "@types/react-dom": "^17.0.9",
     "axios": "^0.21.1",
@@ -22,7 +22,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-highlight.js": "^1.0.7",
-    "react-router-dom": "^5.2.0",
+    "react-router-dom": "^5.3.0",
     "react-scripts": "4.0.3"
   },
   "scripts": {


### PR DESCRIPTION
@sasjs/core from 2.48.2 to 2.48.6
react-router-dom from 5.2.0 to 5.3.0

VIYA:
![image](https://user-images.githubusercontent.com/83717836/139386853-617af1a7-e7c2-47d0-af09-f137b539d7cc.png)
