### PR TITLE
fix: local login component should not pop up when login mechanism is …

### DIFF
--- a/src/context/sasContext.tsx
+++ b/src/context/sasContext.tsx
@@ -138,6 +138,23 @@ const SASProvider = (props: { children: ReactNode }) => {
       if (!startupData) {
         fetchStartupData()
       }
+    } else if (sasjsConfig.loginMechanism === 'Redirected') {
+      sasService
+        .logIn()
+        .then(
+          (res: { isLoggedIn: boolean; userName: string }) => {
+            setIsUserLoggedIn(res.isLoggedIn)
+          },
+          (err) => {
+            console.error(err)
+            setIsUserLoggedIn(false)
+          }
+        )
+        .catch((e) => {
+          if (e === 403) {
+            console.error('Invalid host')
+          }
+        })
     }
   }, [isUserLoggedIn, startupData, fetchStartupData])
 

--- a/src/layouts/Main.jsx
+++ b/src/layouts/Main.jsx
@@ -192,9 +192,11 @@ const Main = (props) => {
           open={open}
         />
       </div>
-      {!(sasContext.isUserLoggedIn || sasContext.checkingSession) && (
-        <LoginComponent />
-      )}
+      {!(
+        window.sasjsConfig.loginMechanism === 'Redirected' ||
+        sasContext.isUserLoggedIn ||
+        sasContext.checkingSession
+      ) && <LoginComponent />}
     </>
   )
 }


### PR DESCRIPTION
…redirected

When the user is not logged in then a login component pops up on the screen. But when login mechanism is redirected then login method of sasjs adapter should be called, that in result will show sas login modal.