### PR TITLE
fix: remove inline script from index.html

### DIFF
--- a/src/context/sasContext.tsx
+++ b/src/context/sasContext.tsx
@@ -26,13 +26,24 @@ interface SASContextProps {
   startupData: any
 }
 
-declare global {
-  interface Window {
-    sasjsConfig: SASjsConfig
-  }
-}
+const sasElement = document.querySelector('sasjs')
 
-const sasjsConfig = window.sasjsConfig as SASjsConfig
+const useComputeApi = sasElement?.getAttribute('useComputeApi')
+
+const sasjsConfig = {
+  serverUrl: sasElement?.getAttribute('serverUrl') ?? undefined,
+  appLoc: sasElement?.getAttribute('appLoc') ?? undefined,
+  serverType: sasElement?.getAttribute('serverType'),
+  debug: sasElement?.getAttribute('debug') === 'true',
+  loginMechanism: sasElement?.getAttribute('loginMechanism') ?? undefined,
+  useComputeApi:
+    useComputeApi === 'true'
+      ? true
+      : useComputeApi === 'false'
+      ? false
+      : useComputeApi,
+  contextName: sasElement?.getAttribute('contextName') ?? undefined
+} as SASjsConfig
 
 const sasService = new SASjs(sasjsConfig)
 

--- a/src/index.html
+++ b/src/index.html
@@ -32,6 +32,22 @@
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
+
+    <!--
+      ## SASJS Adapter config details ##
+
+      * appLoc: The location in metadata or SAS drive where App/services will be deployed
+      * serverType: either SAS9, SASVIYA or SASJS
+      * serverUrl: Url of the server where services are deployed. Can leave blank if frontend and backend is running on same server
+      * loginMechanism: Use 'Default' for regular (user/pass) logins, or 'Redirected' for 2FA/SSO
+      * debug: Whether to enable debug on startup
+
+      ## Viya only settings ##
+      * useComputeApi: either true or false
+      * contextName: Compute Context
+
+    -->
+
     <sasjs
       appLoc="/Public/app/react-seed-app"
       serverType="SASJS"

--- a/src/index.html
+++ b/src/index.html
@@ -32,6 +32,11 @@
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
+    <sasjs
+      appLoc="/Public/app/react-seed-app"
+      serverType="SASJS"
+      debug="false"
+    ></sasjs>
     <div id="root"></div>
     <!--
       This HTML file is a template.
@@ -43,14 +48,5 @@
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
-    <script>
-      window.sasjsConfig = {
-        serverUrl: 'https://sas.analytium.co.uk:5000',
-        appLoc: '/Public/app/react-seed-app',
-        serverType: 'SASJS',
-        debug: false,
-        loginMechanism: 'Redirected'
-      }
-    </script>
   </body>
 </html>

--- a/src/layouts/Main.jsx
+++ b/src/layouts/Main.jsx
@@ -193,7 +193,8 @@ const Main = (props) => {
         />
       </div>
       {!(
-        window.sasjsConfig.loginMechanism === 'Redirected' ||
+        document.querySelector('sasjs')?.getAttribute('loginMechanism') ===
+          'Redirected' ||
         sasContext.isUserLoggedIn ||
         sasContext.checkingSession
       ) && <LoginComponent />}


### PR DESCRIPTION
To meet strict CSP policy on sasjs/server, we have to remove the inline script from index.html